### PR TITLE
PullRequest for disabling pinning subdomains

### DIFF
--- a/trustkit/src/androidTest/java/com/datatheorem/android/trustkit/config/DomainPinningPolicyTest.java
+++ b/trustkit/src/androidTest/java/com/datatheorem/android/trustkit/config/DomainPinningPolicyTest.java
@@ -76,8 +76,7 @@ public class DomainPinningPolicyTest {
         boolean didReceiveConfigError = false;
         try {
             new DomainPinningPolicy("www.test.com", true, badPins, true, date, reportUris, false);
-        }
-        catch (ConfigurationException e) {
+        } catch (ConfigurationException e) {
             if (e.getMessage().startsWith("Less than two pins")) {
                 didReceiveConfigError = true;
             } else {
@@ -87,10 +86,23 @@ public class DomainPinningPolicyTest {
         assertTrue(didReceiveConfigError);
     }
 
+    
     @Test
     public void testNoPinsButPinningEnforceDisabledShouldBeValid() throws MalformedURLException {
         Set<String> emptyPins = new HashSet<>();
-        new DomainPinningPolicy("www.test.com", true, emptyPins, false, date, reportUris, false);
+        boolean didReceivedConfigError = false;
+
+        try {
+            new DomainPinningPolicy("www.test.com", true, emptyPins, true, date, reportUris, false);
+        } catch (ConfigurationException e) {
+            if (e.getMessage().startsWith("An empty pin-set")) {
+                didReceivedConfigError = true;
+            } else {
+                throw e;
+            }
+        }
+        
+        assertTrue(didReceivedConfigError);
     }
 
     @Test

--- a/trustkit/src/androidTest/java/com/datatheorem/android/trustkit/config/DomainPinningPolicyTest.java
+++ b/trustkit/src/androidTest/java/com/datatheorem/android/trustkit/config/DomainPinningPolicyTest.java
@@ -88,6 +88,12 @@ public class DomainPinningPolicyTest {
     }
 
     @Test
+    public void testNoPinsButPinningEnforceDisabledShouldBeValid() throws MalformedURLException {
+        Set<String> emptyPins = new HashSet<>();
+        new DomainPinningPolicy("www.test.com", true, emptyPins, false, date, reportUris, false);
+    }
+
+    @Test
     public void testBadPolicyPinTld() throws MalformedURLException {
         boolean didReceiveConfigError = false;
         try {

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/config/DomainPinningPolicy.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/config/DomainPinningPolicy.java
@@ -51,7 +51,7 @@ public final class DomainPinningPolicy {
         // Check if the configuration has at least two pins (including a backup pin)
         // TrustKit should not work if the configuration contains only one pin
         // more info (https://tools.ietf.org/html/rfc7469#page-21)
-        if (publicKeyHashStrList.size() < 2) {
+        if (publicKeyHashStrList.size() < 2 && shouldEnforcePinning) {
             throw new ConfigurationException("Less than two pins were supplied "+
                     "for domain " + this.hostname + ". This might " +
                     "brick your App; please review the Getting Started guide in " +


### PR DESCRIPTION
As mentionned by @omerlh in #8 the Android framework in N skip subdomains when the developer is specifying an empty <pin-set> in a nested <domain-config>. TrustKit Android provides a enforcePinning parameter for the config and should not let the developer uses both at the same time. We should also differentiate the missing backup pin error and this one, because it could hide it behind our current check. 