### PR TITLE
extract pinning validation logic to class

### DIFF
--- a/trustkit/src/androidTest/java/com/datatheorem/android/trustkit/pinning/PinningValidatorTest.java
+++ b/trustkit/src/androidTest/java/com/datatheorem/android/trustkit/pinning/PinningValidatorTest.java
@@ -1,0 +1,314 @@
+package com.datatheorem.android.trustkit.pinning;
+
+import android.content.Context;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.datatheorem.android.trustkit.CertificateUtils;
+import com.datatheorem.android.trustkit.TestableTrustKit;
+import com.datatheorem.android.trustkit.config.DomainPinningPolicy;
+import com.datatheorem.android.trustkit.config.PublicKeyPin;
+import com.datatheorem.android.trustkit.reporting.BackgroundReporter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSocketFactory;
+
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN)
+@RunWith(MockitoJUnitRunner.class)
+public class PinningValidatorTest {
+
+    @Mock
+    private BackgroundReporter mockReporter;
+
+    // The root CA for cacert.org; useful to test connections with a custom CA
+    private final String caCertDotOrgRootPem =
+            "MIIHPTCCBSWgAwIBAgIBADANBgkqhkiG9w0BAQQFADB5MRAwDgYDVQQKEwdSb290\n" +
+                    "IENBMR4wHAYDVQQLExVodHRwOi8vd3d3LmNhY2VydC5vcmcxIjAgBgNVBAMTGUNB\n" +
+                    "IENlcnQgU2lnbmluZyBBdXRob3JpdHkxITAfBgkqhkiG9w0BCQEWEnN1cHBvcnRA\n" +
+                    "Y2FjZXJ0Lm9yZzAeFw0wMzAzMzAxMjI5NDlaFw0zMzAzMjkxMjI5NDlaMHkxEDAO\n" +
+                    "BgNVBAoTB1Jvb3QgQ0ExHjAcBgNVBAsTFWh0dHA6Ly93d3cuY2FjZXJ0Lm9yZzEi\n" +
+                    "MCAGA1UEAxMZQ0EgQ2VydCBTaWduaW5nIEF1dGhvcml0eTEhMB8GCSqGSIb3DQEJ\n" +
+                    "ARYSc3VwcG9ydEBjYWNlcnQub3JnMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIIC\n" +
+                    "CgKCAgEAziLA4kZ97DYoB1CW8qAzQIxL8TtmPzHlawI229Z89vGIj053NgVBlfkJ\n" +
+                    "8BLPRoZzYLdufujAWGSuzbCtRRcMY/pnCujW0r8+55jE8Ez64AO7NV1sId6eINm6\n" +
+                    "zWYyN3L69wj1x81YyY7nDl7qPv4coRQKFWyGhFtkZip6qUtTefWIonvuLwphK42y\n" +
+                    "fk1WpRPs6tqSnqxEQR5YYGUFZvjARL3LlPdCfgv3ZWiYUQXw8wWRBB0bF4LsyFe7\n" +
+                    "w2t6iPGwcswlWyCR7BYCEo8y6RcYSNDHBS4CMEK4JZwFaz+qOqfrU0j36NK2B5jc\n" +
+                    "G8Y0f3/JHIJ6BVgrCFvzOKKrF11myZjXnhCLotLddJr3cQxyYN/Nb5gznZY0dj4k\n" +
+                    "epKwDpUeb+agRThHqtdB7Uq3EvbXG4OKDy7YCbZZ16oE/9KTfWgu3YtLq1i6L43q\n" +
+                    "laegw1SJpfvbi1EinbLDvhG+LJGGi5Z4rSDTii8aP8bQUWWHIbEZAWV/RRyH9XzQ\n" +
+                    "QUxPKZgh/TMfdQwEUfoZd9vUFBzugcMd9Zi3aQaRIt0AUMyBMawSB3s42mhb5ivU\n" +
+                    "fslfrejrckzzAeVLIL+aplfKkQABi6F1ITe1Yw1nPkZPcCBnzsXWWdsC4PDSy826\n" +
+                    "YreQQejdIOQpvGQpQsgi3Hia/0PsmBsJUUtaWsJx8cTLc6nloQsCAwEAAaOCAc4w\n" +
+                    "ggHKMB0GA1UdDgQWBBQWtTIb1Mfz4OaO873SsDrusjkY0TCBowYDVR0jBIGbMIGY\n" +
+                    "gBQWtTIb1Mfz4OaO873SsDrusjkY0aF9pHsweTEQMA4GA1UEChMHUm9vdCBDQTEe\n" +
+                    "MBwGA1UECxMVaHR0cDovL3d3dy5jYWNlcnQub3JnMSIwIAYDVQQDExlDQSBDZXJ0\n" +
+                    "IFNpZ25pbmcgQXV0aG9yaXR5MSEwHwYJKoZIhvcNAQkBFhJzdXBwb3J0QGNhY2Vy\n" +
+                    "dC5vcmeCAQAwDwYDVR0TAQH/BAUwAwEB/zAyBgNVHR8EKzApMCegJaAjhiFodHRw\n" +
+                    "czovL3d3dy5jYWNlcnQub3JnL3Jldm9rZS5jcmwwMAYJYIZIAYb4QgEEBCMWIWh0\n" +
+                    "dHBzOi8vd3d3LmNhY2VydC5vcmcvcmV2b2tlLmNybDA0BglghkgBhvhCAQgEJxYl\n" +
+                    "aHR0cDovL3d3dy5jYWNlcnQub3JnL2luZGV4LnBocD9pZD0xMDBWBglghkgBhvhC\n" +
+                    "AQ0ESRZHVG8gZ2V0IHlvdXIgb3duIGNlcnRpZmljYXRlIGZvciBGUkVFIGhlYWQg\n" +
+                    "b3ZlciB0byBodHRwOi8vd3d3LmNhY2VydC5vcmcwDQYJKoZIhvcNAQEEBQADggIB\n" +
+                    "ACjH7pyCArpcgBLKNQodgW+JapnM8mgPf6fhjViVPr3yBsOQWqy1YPaZQwGjiHCc\n" +
+                    "nWKdpIevZ1gNMDY75q1I08t0AoZxPuIrA2jxNGJARjtT6ij0rPtmlVOKTV39O9lg\n" +
+                    "18p5aTuxZZKmxoGCXJzN600BiqXfEVWqFcofN8CCmHBh22p8lqOOLlQ+TyGpkO/c\n" +
+                    "gr/c6EWtTZBzCDyUZbAEmXZ/4rzCahWqlwQ3JNgelE5tDlG+1sSPypZt90Pf6DBl\n" +
+                    "Jzt7u0NDY8RD97LsaMzhGY4i+5jhe1o+ATc7iwiwovOVThrLm82asduycPAtStvY\n" +
+                    "sONvRUgzEv/+PDIqVPfE94rwiCPCR/5kenHA0R6mY7AHfqQv0wGP3J8rtsYIqQ+T\n" +
+                    "SCX8Ev2fQtzzxD72V7DX3WnRBnc0CkvSyqD/HMaMyRa+xMwyN2hzXwj7UfdJUzYF\n" +
+                    "CpUCTPJ5GhD22Dp1nPMd8aINcGeGG7MW9S/lpOt5hvk9C8JzC6WZrG/8Z7jlLwum\n" +
+                    "GCSNe9FINSkYQKyTYOGWhlC0elnYjyELn8+CkcY7v2vcB5G5l1YjqrZslMZIBjzk\n" +
+                    "zk6q5PYvCdxTby78dOs6Y5nCpqyJvKeyRKANihDjbPIky/qbn3BHLt4Ui9SyIAmW\n" +
+                    "omTxJBzcoTWcFbLUvFUufQb1nA5V9FrWk9p2rSVzTMVD\n";
+    private final Certificate caCertDotOrgRoot
+            = CertificateUtils.certificateFromPem(caCertDotOrgRootPem);
+
+    @Before
+    public void setUp() {
+        TestableTrustKit.reset();
+    }
+
+    //region Tests for when the domain is pinned
+    @Test
+    public void testPinnedDomainSuccessAnchor() throws IOException {
+        String serverHostname = "www.cacert.org";
+        final DomainPinningPolicy domainPolicy = new DomainPinningPolicy.Builder()
+                .setHostname(serverHostname)
+                .setShouldEnforcePinning(true)
+                .setPublicKeyHashes(new HashSet<String>() {{
+                    // Wrong pins
+                    add("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
+                    add(new PublicKeyPin(CertificateUtils.testCertChain.get(1)).toString());
+                }}).build();
+
+        TestableTrustKit.init(new HashSet<DomainPinningPolicy>() {{ add(domainPolicy); }},
+                InstrumentationRegistry.getContext(),
+                mockReporter);
+
+        PinningValidator test = new PinningValidator();
+
+        PinningValidationResult result = test.evaluateTrust(CertificateUtils.testCertChain.toArray(new X509Certificate[CertificateUtils.testCertChain.size()]), serverHostname);
+
+        assertEquals(PinningValidationResult.SUCCESS, result);
+
+        // Ensure the background reporter was NOT called
+        verify(mockReporter, never()).pinValidationFailed(
+                eq(serverHostname),
+                eq(0),
+                (List<X509Certificate>) org.mockito.Matchers.isNotNull(),
+                (List<X509Certificate>) org.mockito.Matchers.isNotNull(),
+                eq(TestableTrustKit.getInstance().getConfiguration().getPolicyForHostname(serverHostname)),
+                eq(PinningValidationResult.SUCCESS)
+        );
+    }
+
+
+    @Test
+    public void testPinnedDomainSuccessLeaf() throws IOException {
+        String serverHostname = "www.cacert.org";
+        final DomainPinningPolicy domainPolicy = new DomainPinningPolicy.Builder()
+                .setHostname(serverHostname)
+                .setShouldEnforcePinning(true)
+                .setPublicKeyHashes(new HashSet<String>() {{
+                    // Wrong pins
+                    add("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
+                    add(new PublicKeyPin(CertificateUtils.testCertChain.get(0)).toString());
+                }}).build();
+
+        TestableTrustKit.init(new HashSet<DomainPinningPolicy>() {{ add(domainPolicy); }},
+                InstrumentationRegistry.getContext(),
+                mockReporter);
+
+        PinningValidator test = new PinningValidator();
+
+        PinningValidationResult result = test.evaluateTrust(CertificateUtils.testCertChain.toArray(new X509Certificate[CertificateUtils.testCertChain.size()]), serverHostname);
+
+        assertEquals(PinningValidationResult.SUCCESS, result);
+
+        // Ensure the background reporter was NOT called
+        verify(mockReporter, never()).pinValidationFailed(
+                eq(serverHostname),
+                eq(0),
+                (List<X509Certificate>) org.mockito.Matchers.isNotNull(),
+                (List<X509Certificate>) org.mockito.Matchers.isNotNull(),
+                eq(TestableTrustKit.getInstance().getConfiguration().getPolicyForHostname(serverHostname)),
+                eq(PinningValidationResult.SUCCESS)
+        );
+    }
+
+    @Test
+    public void testPinnedDomainInvalidPin() throws IOException {
+        String serverHostname = "www.cacert.org";
+        final DomainPinningPolicy domainPolicy = new DomainPinningPolicy.Builder()
+                .setHostname(serverHostname)
+                .setShouldEnforcePinning(true)
+                .setPublicKeyHashes(new HashSet<String>() {{
+                    // Wrong pins
+                    add("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
+                    add("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=");
+                }}).build();
+
+        TestableTrustKit.init(new HashSet<DomainPinningPolicy>() {{ add(domainPolicy); }},
+                InstrumentationRegistry.getContext(),
+                mockReporter);
+
+        PinningValidator test = new PinningValidator();
+
+        // Create a TrustKit SocketFactory and ensure the connection fails
+        PinningValidationResult result = test.evaluateTrust(CertificateUtils.testCertChain.toArray(new X509Certificate[CertificateUtils.testCertChain.size()]), serverHostname);
+
+        assertEquals(PinningValidationResult.FAILED, result);
+
+        // Ensure the background reporter was called
+        verify(mockReporter, times(1)).pinValidationFailed(
+                eq(serverHostname),
+                eq(0),
+                (List<X509Certificate>) org.mockito.Matchers.isNotNull(),
+                (List<X509Certificate>) org.mockito.Matchers.isNotNull(),
+                eq(TestableTrustKit.getInstance().getConfiguration().getPolicyForHostname(serverHostname)),
+                eq(PinningValidationResult.FAILED)
+        );
+    }
+
+    @Test
+    public void testPinnedDomainInvalidPinAndPinningNotEnforced() throws IOException {
+        String serverHostname = "www.cacert.org";
+        final DomainPinningPolicy domainPolicy = new DomainPinningPolicy.Builder()
+                .setHostname(serverHostname)
+                .setShouldEnforcePinning(false)
+                .setPublicKeyHashes(new HashSet<String>() {{
+                    // Wrong pins
+                    add("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
+                    add("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=");
+                }}).build();
+
+        TestableTrustKit.init(new HashSet<DomainPinningPolicy>() {{ add(domainPolicy); }},
+                InstrumentationRegistry.getContext(),
+                mockReporter);
+
+        PinningValidator test = new PinningValidator();
+
+        // Create a TrustKit SocketFactory and ensure the connection fails
+        PinningValidationResult result = test.evaluateTrust(CertificateUtils.testCertChain.toArray(new X509Certificate[CertificateUtils.testCertChain.size()]), serverHostname);
+
+        assertEquals(PinningValidationResult.SUCCESS, result);
+
+        // Ensure the background reporter was called
+        verify(mockReporter, times(1)).pinValidationFailed(
+                eq(serverHostname),
+                eq(0),
+                (List<X509Certificate>) org.mockito.Matchers.isNotNull(),
+                (List<X509Certificate>) org.mockito.Matchers.isNotNull(),
+                eq(TestableTrustKit.getInstance().getConfiguration().getPolicyForHostname(serverHostname)),
+                eq(PinningValidationResult.FAILED)
+        );
+    }
+
+    @Test
+    public void testPinnedDomainInvalidPinAndPolicyExpired() throws IOException {
+        String serverHostname = "www.cacert.org";
+
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(new Date());
+        cal.add(Calendar.DATE, -30);
+        Date dateBefore30Days = cal.getTime();
+
+        final DomainPinningPolicy domainPolicy = new DomainPinningPolicy.Builder()
+                .setHostname(serverHostname)
+                .setExpirationDate(dateBefore30Days)
+                .setShouldEnforcePinning(false)
+                .setPublicKeyHashes(new HashSet<String>() {{
+                    // Wrong pins
+                    add("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
+                    add(new PublicKeyPin(CertificateUtils.testCertChain.get(0)).toString());
+                }}).build();
+
+        TestableTrustKit.init(new HashSet<DomainPinningPolicy>() {{ add(domainPolicy); }},
+                InstrumentationRegistry.getContext(),
+                mockReporter);
+
+        PinningValidator test = new PinningValidator();
+
+        // Create a TrustKit SocketFactory and ensure the connection fails
+        PinningValidationResult result = test.evaluateTrust(CertificateUtils.testCertChain.toArray(new X509Certificate[CertificateUtils.testCertChain.size()]), serverHostname);
+
+        assertEquals(PinningValidationResult.SUCCESS, result);
+
+        // Ensure the background reporter was called
+        verify(mockReporter, never()).pinValidationFailed(
+                eq(serverHostname),
+                eq(0),
+                (List<X509Certificate>) org.mockito.Matchers.isNotNull(),
+                (List<X509Certificate>) org.mockito.Matchers.isNotNull(),
+                eq(TestableTrustKit.getInstance().getConfiguration().getPolicyForHostname(serverHostname)),
+                eq(PinningValidationResult.SUCCESS)
+        );
+    }
+
+    @Test
+    public void testNonPinnedDomainSuccess() throws IOException {
+        String serverHostname = "www.cacert.org";
+        final DomainPinningPolicy domainPolicy = new DomainPinningPolicy.Builder()
+                .setHostname("other.domain.com")
+                .setShouldEnforcePinning(false)
+                .setPublicKeyHashes(new HashSet<String>() {{
+                    // Wrong pins
+                    add("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
+                    add("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=");
+                }}).build();
+
+        TestableTrustKit.init(new HashSet<DomainPinningPolicy>() {{ add(domainPolicy); }},
+                InstrumentationRegistry.getContext(),
+                mockReporter);
+
+        PinningValidator test = new PinningValidator();
+
+        // Create a TrustKit SocketFactory and ensure the connection fails
+        PinningValidationResult result = test.evaluateTrust(CertificateUtils.testCertChain.toArray(new X509Certificate[CertificateUtils.testCertChain.size()]), serverHostname);
+
+        assertEquals(PinningValidationResult.SUCCESS, result);
+
+        // Ensure the background reporter was called
+        verify(mockReporter, never()).pinValidationFailed(
+                eq(serverHostname),
+                eq(0),
+                (List<X509Certificate>) org.mockito.Matchers.isNotNull(),
+                (List<X509Certificate>) org.mockito.Matchers.isNotNull(),
+                eq(TestableTrustKit.getInstance().getConfiguration().getPolicyForHostname(serverHostname)),
+                eq(PinningValidationResult.SUCCESS)
+        );
+    }
+
+    //endregion
+
+}

--- a/trustkit/src/androidTest/java/com/datatheorem/android/trustkit/pinning/SSLSocketFactoryTest.java
+++ b/trustkit/src/androidTest/java/com/datatheorem/android/trustkit/pinning/SSLSocketFactoryTest.java
@@ -2,6 +2,7 @@ package com.datatheorem.android.trustkit.pinning;
 
 import android.content.Context;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -110,7 +111,7 @@ public class SSLSocketFactoryTest {
                 InstrumentationRegistry.getContext(), mockReporter);
 
         // Create a TrustKit SocketFactory and ensure the connection fails
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         boolean didReceiveHandshakeError = false;
         try {
             test.createSocket(serverHostname, 443).getInputStream();
@@ -146,7 +147,7 @@ public class SSLSocketFactoryTest {
                 InstrumentationRegistry.getContext(), mockReporter);
 
         // Create a TrustKit SocketFactory and ensure the connection fails
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         boolean didReceiveHandshakeError = false;
         try {
             test.createSocket(serverHostname, 443).getInputStream();
@@ -181,7 +182,7 @@ public class SSLSocketFactoryTest {
                 InstrumentationRegistry.getContext(), mockReporter);
 
         // Create a TrustKit SocketFactory and ensure the connection succeeds
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         Socket socket = test.createSocket(serverHostname, 443);
         socket.getInputStream();
 
@@ -206,7 +207,7 @@ public class SSLSocketFactoryTest {
                 InstrumentationRegistry.getContext(), mockReporter);
 
         // Create a TrustKit SocketFactory and ensure the connection succeeds
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         Socket socket = test.createSocket(serverHostname, 443);
         socket.getInputStream();
 
@@ -236,7 +237,7 @@ public class SSLSocketFactoryTest {
                 InstrumentationRegistry.getContext(), mockReporter);
 
         // Create a TrustKit SocketFactory and ensure the connection fails
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         boolean didReceivePinningError = false;
         try {
             test.createSocket(serverHostname, 443).getInputStream();
@@ -266,7 +267,7 @@ public class SSLSocketFactoryTest {
                 InstrumentationRegistry.getContext(), mockReporter);
 
         // Create a TrustKit SocketFactory and ensure the connection succeeds
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         Socket socket = test.createSocket(serverHostname, 443);
         socket.getInputStream();
 
@@ -296,7 +297,7 @@ public class SSLSocketFactoryTest {
                 InstrumentationRegistry.getContext(), mockReporter);
 
         // Create a TrustKit SocketFactory and ensure the connection succeeds
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         Socket socket = test.createSocket(serverHostname, 443);
         socket.getInputStream();
 
@@ -321,7 +322,7 @@ public class SSLSocketFactoryTest {
                 InstrumentationRegistry.getContext(), mockReporter);
 
         // Create a TrustKit SocketFactory and ensure the connection fails
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         boolean didReceiveHandshakeError = false;
         try {
             test.createSocket(serverHostname, 443).getInputStream();
@@ -385,7 +386,7 @@ public class SSLSocketFactoryTest {
         // Create a TrustKit SocketFactory and ensure the connection succeeds
         // This means that debug-overrides properly enables the supplied debug CA cert and
         // disables pinning when overridePins is true
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         Socket socket = test.createSocket(serverHostname, 443);
         socket.getInputStream();
 
@@ -440,7 +441,7 @@ public class SSLSocketFactoryTest {
 
         // Create a TrustKit SocketFactory and ensure the connection fails
         // This means that debug-overrides property was ignored because the App is not debuggable
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         boolean didReceiveHandshakeError = false;
         try {
             test.createSocket(serverHostname, 443).getInputStream();
@@ -493,7 +494,7 @@ public class SSLSocketFactoryTest {
         // Create a TrustKit SocketFactory and ensure the connection fails
         // This means that debug-overrides properly enables the supplied debug CA cert but does not
         // disable pinning when overridePins is false
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         boolean didReceivePinningError = false;
         try {
             test.createSocket(serverHostname, 443).getInputStream();
@@ -536,7 +537,7 @@ public class SSLSocketFactoryTest {
 
         // Create a TrustKit SocketFactory and ensure the connection fails
         // This means that TrustKit does not interfere with default certificate validation
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         boolean didReceiveHandshakeError = false;
         try {
             test.createSocket(serverHostname, 443).getInputStream();
@@ -567,7 +568,7 @@ public class SSLSocketFactoryTest {
                 InstrumentationRegistry.getContext(), mockReporter);
 
         // Create a TrustKit SocketFactory and ensure the connection succeeds
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         Socket socket = test.createSocket(serverHostname, 443);
         socket.getInputStream();
 
@@ -618,7 +619,7 @@ public class SSLSocketFactoryTest {
 
         // Create a TrustKit SocketFactory and ensure the connection succeeds
         // This means that debug-overrides properly enables the supplied debug CA cert
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         Socket socket = test.createSocket(serverHostname, 443);
         socket.getInputStream();
 
@@ -665,7 +666,7 @@ public class SSLSocketFactoryTest {
 
         // Create a TrustKit SocketFactory and ensure the connection succeeds
         // This means that debug-overrides does not disable the System CAs
-        SSLSocketFactory test = TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+        SSLSocketFactory test = getSslSocketFactory(serverHostname);
         Socket socket = test.createSocket(serverHostname, 443);
         socket.getInputStream();
 
@@ -683,4 +684,14 @@ public class SSLSocketFactoryTest {
         );
     }
     //endregion
+
+
+    @NonNull
+    private SSLSocketFactory getSslSocketFactory(String serverHostname) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            return TestableTrustKit.getInstance().getSSLSocketFactory();
+        }
+
+        return TestableTrustKit.getInstance().getSSLSocketFactory(serverHostname);
+    }
 }

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/PinningTrustManager.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/PinningTrustManager.java
@@ -44,7 +44,7 @@ class PinningTrustManager implements X509TrustManager {
     public PinningTrustManager(@NonNull String serverHostname,
                                @NonNull X509TrustManager baselineTrustManager) {
         // Store server's information
-        this.serverHostname = null;
+        this.serverHostname = serverHostname;
 
         if (Build.VERSION.SDK_INT < 17) {
             // No pinning validation at all for API level < 17
@@ -74,7 +74,7 @@ class PinningTrustManager implements X509TrustManager {
      */
     @RequiresApi(api = Build.VERSION_CODES.N)
     public PinningTrustManager(@NonNull X509TrustManager baselineTrustManager) {
-        serverHostname = "";
+        serverHostname = null;
         this.baselineTrustManager = new X509TrustManagerExtensions(baselineTrustManager);
     }
 

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/PinningValidator.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/PinningValidator.java
@@ -1,0 +1,67 @@
+package com.datatheorem.android.trustkit.pinning;
+
+import android.os.Build;
+import android.support.annotation.RequiresApi;
+import com.datatheorem.android.trustkit.TrustKit;
+import com.datatheorem.android.trustkit.config.DomainPinningPolicy;
+import com.datatheorem.android.trustkit.config.PublicKeyPin;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+@RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN)
+public class PinningValidator {
+
+    public static PinningValidationResult evaluateTrust(X509Certificate[] serverChain, String serverHostname){
+        DomainPinningPolicy serverConfig =
+                TrustKit.getInstance().getConfiguration().getPolicyForHostname(serverHostname);
+        List<X509Certificate> serverChainAsList = Arrays.asList(serverChain);
+
+        if (serverConfig == null) {
+            // Domain is NOT pinned or there is a debug override - only do baseline validation
+            return PinningValidationResult.SUCCESS;
+        }
+
+        boolean hasPinningPolicyExpired = (serverConfig.getExpirationDate() != null)
+                && (serverConfig.getExpirationDate().compareTo(new Date()) < 0);
+
+        boolean didPinningValidationFail = false;
+
+        // Only do pinning validation if the policy has not expired
+        if (!hasPinningPolicyExpired) {
+            didPinningValidationFail = !isPinInChain(serverChainAsList,
+                    serverConfig.getPublicKeyPins());
+        }
+
+        PinningValidationResult validationResult = PinningValidationResult.FAILED;
+
+        if (didPinningValidationFail) {
+            validationResult = PinningValidationResult.FAILED;
+            TrustManagerBuilder.getReporter().pinValidationFailed(serverHostname, 0,
+                    serverChainAsList, serverChainAsList, serverConfig, validationResult);
+        }
+
+        if (!didPinningValidationFail || !serverConfig.shouldEnforcePinning()){
+            validationResult = PinningValidationResult.SUCCESS;
+        }
+
+        return validationResult;
+    }
+
+    private static boolean isPinInChain(List<X509Certificate> verifiedServerChain,
+                                        Set<PublicKeyPin> configuredPins) {
+        boolean wasPinFound = false;
+        for (Certificate certificate : verifiedServerChain) {
+            PublicKeyPin certificatePin = new PublicKeyPin(certificate);
+            if (configuredPins.contains(certificatePin)) {
+                // Pinning validation succeeded
+                wasPinFound = true;
+                break;
+            }
+        }
+        return wasPinFound;
+    }
+}

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/TrustManagerBuilder.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/TrustManagerBuilder.java
@@ -73,7 +73,21 @@ public class TrustManagerBuilder {
             // Domain is NOT pinned or there is a debug override - only do baseline validation
             return baselineTrustManager;
         } else {
-            return new PinningTrustManager(serverHostname, serverConfig, baselineTrustManager);
+            return new PinningTrustManager(serverHostname, baselineTrustManager);
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    public static X509TrustManager getTrustManager() {
+        if (baselineTrustManager == null) {
+            throw new IllegalStateException("TrustManagerBuilder has not been initialized");
+        }
+
+        if (shouldOverridePins) {
+            // Domain is NOT pinned or there is a debug override - only do baseline validation
+            return baselineTrustManager;
+        } else {
+            return new PinningTrustManager(baselineTrustManager);
         }
     }
 


### PR DESCRIPTION
This should solve #6 - it will allow me to use only the pinning logic in the interceptor, without the complexity of calling to TrustManager api.