### PR TITLE
Update OkHostnameVerifier in TrustKit-Android

### DIFF
--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/OkHostnameVerifier.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/OkHostnameVerifier.java
@@ -57,9 +57,9 @@ final class OkHostnameVerifier implements HostnameVerifier {
     }
 
     public boolean verify(String host, X509Certificate certificate) {
-        // TrustKit: Removed support here for IP addresses so we don't need to import more files
-        // from OkHttp
-        return verifyHostname(host, certificate);
+        return Utils.verifyAsIpAddress(host)
+            ? verifyIpAddress(host, certificate)
+            : verifyHostname(host, certificate);
     }
 
     /** Returns true if {@code certificate} matches {@code ipAddress}. */

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/Utils.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/Utils.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2012 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datatheorem.android.trustkit.pinning;
+
+import java.util.regex.Pattern;
+
+/** Junk drawer of utility methods. */
+final class Utils {
+  /**
+   * Quick and dirty pattern to differentiate IP addresses from hostnames. This is an approximation
+   * of Android's private InetAddress#isNumeric API.
+   *
+   * <p>This matches IPv6 addresses as a hex string containing at least one colon, and possibly
+   * including dots after the first colon. It matches IPv4 addresses as strings containing only
+   * decimal digits and dots. This pattern matches strings like "a:.23" and "54" that are neither IP
+   * addresses nor hostnames; they will be verified as IP addresses (which is a more strict
+   * verification).
+   */
+  private static final Pattern VERIFY_AS_IP_ADDRESS = Pattern.compile(
+      "([0-9a-fA-F]*:[0-9a-fA-F:.]*)|([\\d.]+)");
+
+
+  /** Returns true if {@code host} is not a host name and might be an IP address. */
+  public static boolean verifyAsIpAddress(String host) {
+    return VERIFY_AS_IP_ADDRESS.matcher(host).matches();
+  }
+}


### PR DESCRIPTION
Support all the features proposed by the original OkHostnameVerifier compare to the one we have now. Most probably addressing the issue https://github.com/datatheorem/TrustKit-Android/issues/23