### PR TITLE
add getter for all domains into TrustKitConfiguration

### DIFF
--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/config/TrustKitConfiguration.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/config/TrustKitConfiguration.java
@@ -66,6 +66,15 @@ public class TrustKitConfiguration {
     }
 
     /**
+     * Get the Set of {@link DomainPinningPolicy}.
+     *
+     * @return Set<DomainPinningPolicy> the set of domain's policy
+     */
+    public Set<DomainPinningPolicy> getAllPolicies() {
+        return this.domainPolicies;
+    }
+
+    /**
      * Get the {@link DomainPinningPolicy} corresponding to the provided hostname.
      * When matching the most specific matching domain rule will be used, if no match exists
      * then null will be returned.


### PR DESCRIPTION
This PR is trying to address https://github.com/datatheorem/TrustKit-Android/issues/33

- Adding getter for all domains in the configuration