### PR TITLE
Remove app name specification from library

### DIFF
--- a/trustkit/src/androidTest/AndroidManifest.xml
+++ b/trustkit/src/androidTest/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <application android:label="@string/app_name" android:networkSecurityConfig="@xml/network_security_config" android:debuggable="true">
+    <application android:networkSecurityConfig="@xml/network_security_config" android:debuggable="true">
     </application>
 
 </manifest>

--- a/trustkit/src/main/AndroidManifest.xml
+++ b/trustkit/src/main/AndroidManifest.xml
@@ -1,10 +1,1 @@
-<manifest package="com.datatheorem.android.trustkit"
-          xmlns:android="http://schemas.android.com/apk/res/android">
-
-
-    <application
-        android:label="@string/app_name">
-
-    </application>
-
-</manifest>
+<manifest package="com.datatheorem.android.trustkit"/>

--- a/trustkit/src/main/res/values/strings.xml
+++ b/trustkit/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">TrustKit</string>
-</resources>


### PR DESCRIPTION
Library should not specify application label and app_name string

Came across this while setting up new flavor. While app_name string was still missing my app name was set to `TrustKit`