### PR TITLE
Align build.gradle step within Getting Started guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ configuration from a PEM or DER certificate:
 
 Add TrustKit to your project's _build.gradle_:
 
-`compile 'com.datatheorem.truskit:trustkit-android:'`
+`implementation 'com.datatheorem.android.trustkit:trustkit:<last_version>'`
 
 ### Configuring a Pinning Policy
 


### PR DESCRIPTION
Noticed [others](https://github.com/datatheorem/TrustKit-Android/issues/75) were having a similar issue following the Getting Started guide. This PR simply aligns with the step detailed within the README.