### PR TITLE
Maven migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,8 @@ buildscript {
     ext.kotlin_version = '1.3.21'
 
     repositories {
-        jcenter()
+        mavenCentral()
+        jcenter() // TODO: Remove when org.jetbrains.trove4j:trove4j moves to Maven Central
         google()
     }
     dependencies {
@@ -17,7 +18,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
+        jcenter() // TODO: Remove when org.jetbrains.trove4j:trove4j moves to Maven Central
         google()
     }
     apply plugin: 'maven'
@@ -26,8 +28,8 @@ allprojects {
 
 
 ext{
-    trustkitVersionCode = 9
-    trustkitVersionName = "1.1.3"
+    trustkitVersionCode = 10
+    trustkitVersionName = "1.1.4"
 
     demoAppTrustKitVersionCode = 2
     demoAppTrustKitVersionName = "1.1"

--- a/build.gradle
+++ b/build.gradle
@@ -24,12 +24,12 @@ allprojects {
     }
     apply plugin: 'maven'
     apply plugin: 'maven-publish'
-}
+}:
 
 
 ext{
     trustkitVersionCode = 10
-    trustkitVersionName = "1.1.4"
+    trustkitVersionName = "1.1.5"
 
     demoAppTrustKitVersionCode = 2
     demoAppTrustKitVersionName = "1.1"

--- a/deploymentScripts/publish-mavencentral.gradle
+++ b/deploymentScripts/publish-mavencentral.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 ext {
     PUBLISH_GROUP_ID = 'com.datatheorem.android.trustkit'
     PUBLISH_VERSION = trustkitVersionName
-    PUBLISH_ARTIFACT_ID = 'TrustKit-Android'
+    PUBLISH_ARTIFACT_ID = 'trustkit'
     DESCRIPTION = 'TrustKit Android is an open source library that makes it easy to deploy SSL public key pinning and reporting in any Android App.'
     LICENSE_NAME = 'The MIT License (MIT)'
     LICENSE_URL = 'https://github.com/datatheorem/TrustKit-Android/blob/master/LICENSE'

--- a/deploymentScripts/publish-mavencentral.gradle
+++ b/deploymentScripts/publish-mavencentral.gradle
@@ -1,0 +1,115 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+ext {
+    PUBLISH_GROUP_ID = 'com.datatheorem.android.trustkit'
+    PUBLISH_VERSION = trustkitVersionName
+    PUBLISH_ARTIFACT_ID = 'TrustKit-Android'
+    DESCRIPTION = 'TrustKit Android is an open source library that makes it easy to deploy SSL public key pinning and reporting in any Android App.'
+    LICENSE_NAME = 'The MIT License (MIT)'
+    LICENSE_URL = 'https://github.com/datatheorem/TrustKit-Android/blob/master/LICENSE'
+    PROPERTIES_FILE_NAME = 'local.properties'
+}
+
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    if (project.plugins.findPlugin("com.android.library")) {
+        // For Android libraries
+        from android.sourceSets.main.java.srcDirs
+    }
+}
+
+artifacts {
+    archives androidSourcesJar
+}
+
+group = PUBLISH_GROUP_ID
+version = PUBLISH_VERSION
+
+ext["signing.keyId"] = ''
+ext["signing.password"] = ''
+ext["signing.secretKeyRingFile"] = ''
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+ext["sonatypeStagingProfileId"] = ''
+
+// Read attributes from the local.properties file
+File secretPropsFile = project.rootProject.file(PROPERTIES_FILE_NAME)
+Properties properties = new Properties()
+new FileInputStream(secretPropsFile).withCloseable { is -> properties.load(is)}
+properties.each { name, value -> ext[name] = value }
+
+
+publishing {
+    publications {
+        release(MavenPublication) {
+            // The coordinates of the library, being set from variables that we'll set up later
+            groupId PUBLISH_GROUP_ID
+            artifactId PUBLISH_ARTIFACT_ID
+            version PUBLISH_VERSION
+            // Two artifacts, the `aar` (or `jar`) and the sources
+            if (project.plugins.findPlugin("com.android.library")) {
+                artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
+            } else {
+                artifact("$buildDir/libs/${project.getName()}-${version}.jar")
+            }
+            artifact androidSourcesJar
+            // Mostly self-explanatory metadata
+            pom {
+                name = PUBLISH_ARTIFACT_ID
+                description = DESCRIPTION
+                url = 'https://github.com/datatheorem/TrustKit-Android'
+                licenses {
+                    license {
+                        name = LICENSE_NAME
+                        url = LICENSE_URL
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'nabla-c0d3'
+                        name = 'Alban Diquet'
+                        email = 'ad@datatheorem.io'
+                    }
+                    developer {
+                        id = 'jobot0'
+                        name = 'Jordan Bouellat'
+                        email = 'jb@datatheorem.com'
+                    }
+                }
+                // Version control info
+                scm {
+                    connection = 'scm:git:github.com/datatheorem/TrustKit-Android.git'
+                    developerConnection = 'scm:git:ssh://github.com/datatheorem/TrustKit-Android.git'
+                    url = 'https://github.com/datatheorem/TrustKit-Android/tree/master'
+                }
+                withXml {
+                    def dependenciesNode = asNode().appendNode('dependencies')
+
+                    project.configurations.implementation.allDependencies.each {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+            }
+        }
+    }
+    // The repository to publish to, Sonatype/MavenCentral
+    repositories {
+        maven {
+            // This is an arbitrary name, you may also use "mavencentral" or any other name that's descriptive for you
+            name = "sonatype"
+            url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            credentials {
+                username ossrhUsername
+                password ossrhPassword
+            }
+        }
+    }
+}
+
+signing {
+    sign publishing.publications
+}

--- a/deploymentScripts/publish-mavencentral.gradle
+++ b/deploymentScripts/publish-mavencentral.gradle
@@ -8,57 +8,63 @@ ext {
     DESCRIPTION = 'TrustKit Android is an open source library that makes it easy to deploy SSL public key pinning and reporting in any Android App.'
     LICENSE_NAME = 'The MIT License (MIT)'
     LICENSE_URL = 'https://github.com/datatheorem/TrustKit-Android/blob/master/LICENSE'
+    // Name of properties file stored in project root - contains signing key, auth details, etc.
     PROPERTIES_FILE_NAME = 'local.properties'
+    // Version control info
+    VERSION_CONTROL_CONNECTION = 'scm:git:github.com/datatheorem/TrustKit-Android.git'
+    VERSION_CONTROL_BROWSABLE_URL = 'https://github.com/datatheorem/TrustKit-Android'
 }
 
+// Gradle task to create a 'sources' jar
 task androidSourcesJar(type: Jar) {
     archiveClassifier.set('sources')
-    if (project.plugins.findPlugin("com.android.library")) {
-        // For Android libraries
-        from android.sourceSets.main.java.srcDirs
-    }
+    from android.sourceSets.main.java.srcDirs
 }
 
+// Specify 'androidSourcesJar' as an artifact
+// This artifact will get packaged along with the executable, compiled code.
 artifacts {
     archives androidSourcesJar
 }
 
+// 'group' = namespace for identifying the artifact (.aar file) produced by the build
 group = PUBLISH_GROUP_ID
+
+// 'version' = version of the artifact (.aar file) being published
 version = PUBLISH_VERSION
 
-ext["signing.keyId"] = ''
-ext["signing.password"] = ''
-ext["signing.secretKeyRingFile"] = ''
-ext["ossrhUsername"] = ''
-ext["ossrhPassword"] = ''
-ext["sonatypeStagingProfileId"] = ''
-
-// Read attributes from the local.properties file
+/*
+Read attributes from the 'local.properties' file placed inside project root (Not in version control)
+'local.properties' should contain the following attributes for the deployment to succeed:
+- ossrhPassword
+- signing.secretKeyRingFile
+- signing.password
+- ossrhUsername
+- signing.keyId
+*/
 File secretPropsFile = project.rootProject.file(PROPERTIES_FILE_NAME)
 Properties properties = new Properties()
 new FileInputStream(secretPropsFile).withCloseable { is -> properties.load(is)}
-properties.each { name, value -> ext[name] = value }
-
+// Create 'ext' key-value pairs accessible throughout the gradle file
+properties.each {
+    name, value -> ext[name] = value
+}
 
 publishing {
     publications {
         release(MavenPublication) {
-            // The coordinates of the library, being set from variables that we'll set up later
+            // 'groupId' = namespace, 'artifactId' = library name, 'version' = library version
             groupId PUBLISH_GROUP_ID
             artifactId PUBLISH_ARTIFACT_ID
             version PUBLISH_VERSION
-            // Two artifacts, the `aar` (or `jar`) and the sources
-            if (project.plugins.findPlugin("com.android.library")) {
-                artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
-            } else {
-                artifact("$buildDir/libs/${project.getName()}-${version}.jar")
-            }
+            // Two artifacts, the truskit '.aar' and the sources '.jar'
+            artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
             artifact androidSourcesJar
-            // Mostly self-explanatory metadata
+            // .pom file metadata
             pom {
                 name = PUBLISH_ARTIFACT_ID
                 description = DESCRIPTION
-                url = 'https://github.com/datatheorem/TrustKit-Android'
+                url = VERSION_CONTROL_BROWSABLE_URL
                 licenses {
                     license {
                         name = LICENSE_NAME
@@ -77,15 +83,15 @@ publishing {
                         email = 'jb@datatheorem.com'
                     }
                 }
-                // Version control info
+                // Version control metadata
                 scm {
-                    connection = 'scm:git:github.com/datatheorem/TrustKit-Android.git'
-                    developerConnection = 'scm:git:ssh://github.com/datatheorem/TrustKit-Android.git'
-                    url = 'https://github.com/datatheorem/TrustKit-Android/tree/master'
+                    connection = VERSION_CONTROL_CONNECTION
+                    developerConnection = VERSION_CONTROL_CONNECTION
+                    url = VERSION_CONTROL_BROWSABLE_URL
                 }
+                // Create and populate a 'dependencies' node in .pom file
                 withXml {
                     def dependenciesNode = asNode().appendNode('dependencies')
-
                     project.configurations.implementation.allDependencies.each {
                         def dependencyNode = dependenciesNode.appendNode('dependency')
                         dependencyNode.appendNode('groupId', it.group)
@@ -96,11 +102,16 @@ publishing {
             }
         }
     }
-    // The repository to publish to, Sonatype/MavenCentral
+
+    // Specify repositories where the library needs to be published
     repositories {
         maven {
-            // This is an arbitrary name, you may also use "mavencentral" or any other name that's descriptive for you
-            name = "sonatype"
+            /* The name field can be given an arbitrary value. However changing the name will change the name of the deployment gradle task.
+               For example,
+               if name = "mavencentral", task name will be "publishReleasePublicationToMavencentralRepository"
+               if name = "foo", task name will be "publishReleasePublicationToFooRepository"
+            */
+            name = "mavencentral"
             url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
             credentials {
                 username ossrhUsername
@@ -108,6 +119,7 @@ publishing {
             }
         }
     }
+
 }
 
 signing {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/trustkit/.gitignore
+++ b/trustkit/.gitignore
@@ -1,1 +1,2 @@
 /build
+.DS_STORE

--- a/trustkit/build.gradle
+++ b/trustkit/build.gradle
@@ -1,48 +1,4 @@
-
 apply plugin: 'com.android.library'
-
-ext {
-    userorg = ""
-    bintrayRepo = 'TrustKit-Android'
-    bintrayName = 'trustkit'
-
-    publishedGroupId = 'com.datatheorem.android.trustkit'
-    libraryName = 'TrustKit-Android'
-    artifact = 'trustkit'
-
-    libraryDescription = 'TrustKit Android is an open source library that makes it easy to deploy SSL public key ' +
-            'pinning and reporting in any Android App.'
-    gitUrl = 'https://github.com/datatheorem/TrustKit-Android'
-    websiteUrl = 'https://github.com/datatheorem/TrustKit-Android'
-
-    libraryVersion = trustkitVersionName
-
-    licenseName = 'The MIT License (MIT)'
-    licenseUrl = 'https://github.com/datatheorem/TrustKit-Android/blob/master/LICENSE'
-    allLicenses = ["MIT"]
-}
-
-repositories {
-    mavenCentral()
-}
-dependencies {
-    implementation "androidx.annotation:annotation:$rootProject.libVersions.androidx.annotation"
-    implementation "androidx.legacy:legacy-support-v4:$rootProject.libVersions.androidx.legacySupport"
-    implementation "androidx.preference:preference:$rootProject.libVersions.androidx.preference"
-    compileOnly "com.squareup.okhttp3:okhttp:$rootProject.libVersions.squareup.okhttp3"
-    compileOnly "com.squareup.okhttp:okhttp:$rootProject.libVersions.squareup.okhttp2"
-
-    androidTestImplementation "junit:junit:$rootProject.libVersions.junit"
-    androidTestImplementation "androidx.test:runner:$rootProject.libVersions.androidx.test"
-    androidTestImplementation "androidx.test:rules:$rootProject.libVersions.androidx.test"
-    androidTestImplementation "org.mockito:mockito-core:$rootProject.libVersions.mockito.android"
-    androidTestImplementation "org.awaitility:awaitility:3.1.6"
-    androidTestImplementation "com.crittercism.dexmaker:dexmaker:$rootProject.libVersions.dexmaker"
-    androidTestImplementation "com.crittercism.dexmaker:dexmaker-dx:$rootProject.libVersions.dexmaker"
-    androidTestImplementation "com.crittercism.dexmaker:dexmaker-mockito:$rootProject.libVersions.dexmaker"
-    androidTestImplementation "com.squareup.okhttp3:okhttp:$rootProject.libVersions.testing.okhttp3"
-    androidTestImplementation "com.google.android.gms:play-services-base:$rootProject.libVersions.testing.playServicesBase"
-}
 
 android {
     defaultConfig {
@@ -55,85 +11,21 @@ android {
     }
 }
 
-
-apply plugin: 'com.github.dcendents.android-maven'
-group = publishedGroupId
-
-install {
-    repositories.mavenInstaller {
-        pom {
-            project {
-                packaging 'aar'
-                groupId publishedGroupId
-                artifactId artifact
-
-                name libraryName
-                description libraryDescription
-                url websiteUrl
-
-                licenses {
-                    license {
-                        name licenseName
-                        url licenseUrl
-                    }
-                }
-
-                developers {
-                    developer {
-                        id 'nabla-c0d3'
-                        name 'Alban Diquet'
-                        email 'ad@datatheorem.com'
-                    }
-
-                    developer {
-                        id 'jobot0'
-                        name 'Jordan Bouellat'
-                        email 'jb@datatheorem.com'
-                    }
-                }
-
-                scm {
-                    connection gitUrl
-                    developerConnection gitUrl
-                    url websiteUrl
-                }
-            }
-        }
-    }
+dependencies {
+    implementation "androidx.annotation:annotation:$rootProject.libVersions.androidx.annotation"
+    implementation "androidx.preference:preference:$rootProject.libVersions.androidx.preference"
+    compileOnly "com.squareup.okhttp3:okhttp:$rootProject.libVersions.squareup.okhttp3"
+    compileOnly "com.squareup.okhttp:okhttp:$rootProject.libVersions.squareup.okhttp2"
+    androidTestImplementation "junit:junit:$rootProject.libVersions.junit"
+    androidTestImplementation "androidx.test:runner:$rootProject.libVersions.androidx.test"
+    androidTestImplementation "androidx.test:rules:$rootProject.libVersions.androidx.test"
+    androidTestImplementation "org.mockito:mockito-core:$rootProject.libVersions.mockito.android"
+    androidTestImplementation "org.awaitility:awaitility:3.1.6"
+    androidTestImplementation "com.crittercism.dexmaker:dexmaker:$rootProject.libVersions.dexmaker"
+    androidTestImplementation "com.crittercism.dexmaker:dexmaker-dx:$rootProject.libVersions.dexmaker"
+    androidTestImplementation "com.crittercism.dexmaker:dexmaker-mockito:$rootProject.libVersions.dexmaker"
+    androidTestImplementation "com.squareup.okhttp3:okhttp:$rootProject.libVersions.testing.okhttp3"
+    androidTestImplementation "com.google.android.gms:play-services-base:$rootProject.libVersions.testing.playServicesBase"
 }
 
-apply plugin: 'com.jfrog.bintray'
-
-version = libraryVersion
-// Create artifacts from the source
-task sourcesJar(type: Jar) {
-    classifier = 'sources'
-    from android.sourceSets.main.java.srcDirs
-}
-
-artifacts {
-    archives sourcesJar
-}
-
-bintray {
-        user = System.getenv('BINTRAY_USER')
-        key = System.getenv('BINTRAY_KEY')
-        userorg = System.getenv('BINTRAY_USERORG')
-
-    configurations = ['archives']
-    pkg {
-        repo = bintrayRepo
-        name = bintrayName
-        userOrg = userorg
-        desc = libraryDescription
-        websiteUrl = websiteUrl
-        vcsUrl = gitUrl
-        licenses = allLicenses
-        publish = true
-        version {
-            name = libraryVersion
-            desc = libraryDescription
-        }
-    }
-}
-
+apply from: "${rootProject.projectDir}/deploymentScripts/publish-mavencentral.gradle"

--- a/trustkit/build.gradle
+++ b/trustkit/build.gradle
@@ -28,4 +28,5 @@ dependencies {
     androidTestImplementation "com.google.android.gms:play-services-base:$rootProject.libVersions.testing.playServicesBase"
 }
 
+// MavenCentral deployment gradle script
 apply from: "${rootProject.projectDir}/deploymentScripts/publish-mavencentral.gradle"


### PR DESCRIPTION
- Removed deployment script for bintray/jcenter from the '`trustkit`' module's '`build.gradle`'. This file earlier contained scripts for building an apk as well as publishing to bintray. Now it contains just one reference to the publishing script which is in a separate file. Hence it's down from ~140 lines of code to ~30 lines of code.
- created MavenCentral deployment script called '`publish-mavencentral.gradle`' inside a folder called '`deploymentScripts/`' located inside the project root directory.
- There's a reference to jcenter() in the project level build.gradle which can not be removed until Jetbrains migrates `org.jetbrains.trove4j:trove4j` to MavenCentral.
- Incremented version to 1.1.5 (issues with the 1.1.4 release meant that the only way out was to deploy 1.1.5 as older releases can't be removed from mavencentral)
- Minor update to .gitignore
- Updated gradle version in gradle-wrapper.properties to get rid of warnings

**Procedure to deploy:**
1. Ensure that local.properties file present in the root directory contains the necessary key value pairs such as: `ossrhPassword`, `signing.secretKeyRingFile`, `signing.password`, `ossrhUsername`, `signing.keyId`
2. `./gradlew trustkit:assembleRelease`
3. `./gradlew trustkit:publishReleasePublicationToMavencentralRepository`