### PR TITLE
Maven deployment script bugfix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ allprojects {
     }
     apply plugin: 'maven'
     apply plugin: 'maven-publish'
-}:
+}
 
 
 ext{

--- a/deploymentScripts/publish-mavencentral.gradle
+++ b/deploymentScripts/publish-mavencentral.gradle
@@ -33,6 +33,15 @@ group = PUBLISH_GROUP_ID
 // 'version' = version of the artifact (.aar file) being published
 version = PUBLISH_VERSION
 
+// Set all the variables to a dummy empty string to enable project sync and build without the publication values set up
+// Useful for contributors to the open-source project who don't have MavenCentral deployment credentials
+ext["signing.keyId"] = ''
+ext["signing.password"] = ''
+ext["signing.secretKeyRingFile"] = ''
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+ext["sonatypeStagingProfileId"] = ''
+
 /*
 Read attributes from the 'local.properties' file placed inside project root (Not in version control)
 'local.properties' should contain the following attributes for the deployment to succeed:

--- a/deploymentScripts/publish-mavencentral.gradle
+++ b/deploymentScripts/publish-mavencentral.gradle
@@ -34,7 +34,7 @@ group = PUBLISH_GROUP_ID
 version = PUBLISH_VERSION
 
 // Set all the variables to a dummy empty string to enable project sync and build without the publication values set up
-// Useful for contributors to the open-source project who don't have MavenCentral deployment credentials
+// Useful for contributors to the open-source project who don't have MavenCentral deployment credentials in the local.properties file
 ext["signing.keyId"] = ''
 ext["signing.password"] = ''
 ext["signing.secretKeyRingFile"] = ''


### PR DESCRIPTION
- Fixes an issue in the maven script which caused gradle sync and build to fail unless the contributor had access to deployment credentials for Maven.
- Also fixed minor typo in project-level build.gradle