### PR TITLE
Use TLSv1.2 as minimum SSL/TLS version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ ext{
                     compileSdk : 28,
                     gradlePlugin : '2.1.0',
                     buildTools  : '28.0.3',
-                    minSdk : 15,
+                    minSdk : 16,
                     targetSdk: 28
             ]
     ]

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/TrustKit.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/TrustKit.java
@@ -360,7 +360,7 @@ public class TrustKit {
     @NonNull
     public SSLSocketFactory getSSLSocketFactory(@NonNull String serverHostname) {
         try {
-            SSLContext sslContext = SSLContext.getInstance("TLS");
+            SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
             sslContext.init(null, new TrustManager[]{getTrustManager(serverHostname)}, null);
 
             return sslContext.getSocketFactory();

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/OkHttp2Helper.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/OkHttp2Helper.java
@@ -39,7 +39,7 @@ public class OkHttp2Helper {
     @NonNull
     public static SSLSocketFactory getSSLSocketFactory() {
         try {
-            SSLContext sslContext = SSLContext.getInstance("TLS");
+            SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
             sslContext.init(null, new X509TrustManager[]{trustManager}, null);
 
             return sslContext.getSocketFactory();

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/OkHttp3Helper.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/pinning/OkHttp3Helper.java
@@ -39,7 +39,7 @@ public class OkHttp3Helper {
     @NonNull
     public static SSLSocketFactory getSSLSocketFactory() {
         try {
-            SSLContext sslContext = SSLContext.getInstance("TLS");
+            SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
             sslContext.init(null, new X509TrustManager[]{trustManager}, null);
 
             return sslContext.getSocketFactory();

--- a/trustkit/src/main/java/com/datatheorem/android/trustkit/reporting/BackgroundReporterTask.java
+++ b/trustkit/src/main/java/com/datatheorem/android/trustkit/reporting/BackgroundReporterTask.java
@@ -84,7 +84,7 @@ class BackgroundReporterTask extends AsyncTask<Object, Void, Integer> {
     private static SSLSocketFactory getSystemSSLSocketFactory() {
         SSLContext context;
         try {
-            context = SSLContext.getInstance("TLS");
+            context = SSLContext.getInstance("TLSv1.2");
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("Should never happen");
         }


### PR DESCRIPTION
This has to Increase minimum SDK version to 16 to support configuring TLSv1.2 as the minimum version.